### PR TITLE
Use HotSpot JDK7 instead of OpenJDK7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,19 @@
 # Base operating system image
 FROM centos
 
-# Plus some packages
-RUN yum install -y java-1.7.0-openjdk-devel.x86_64 which
-
+# Install HotSpot JDK 7u51
+RUN wget -O - --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F" "http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-x64.rpm" > /tmp/jdk-7u51-linux-x64.rpm
+RUN rpm -ivh /tmp/jdk-7u51-linux-x64.rpm
+RUN alternatives --install /usr/bin/java java /usr/java/default/bin/java 20000
+RUN rm /tmp/jdk-7u51-linux-x64.rpm
 
 # Install datastax Cassandra
 ADD src/datastax.repo /etc/yum.repos.d/datastax.repo
 RUN yum install -y dsc20
 
-# Create a home directory for cassandra so you can run the client apps
-RUN mkdir -p /home/cassandra
-RUN chown cassandra:cassandra /home/cassandra
-RUN usermod --home /home/cassandra cassandra
+# Create cassandra user home 
+RUN mkdir -p /home/cassandra && chown cassandra: /home/cassandra
+RUN usermod -d /home/cassandra cassandra
 ENV HOME /home/cassandra
 
 ADD src/start.sh /usr/local/bin/start.sh


### PR DESCRIPTION
The modifications allow to download the JDK 7u51 RPM from Oracle website (see cookie's trick) and install it on the system as the default Java JDK (using `alternatives`). This PR fixes pokle/cassandra/issues/2.
