### PR TITLE
fixed escaping of $ chars in JVM_OPTS settings

### DIFF
--- a/cassandra/src/start.sh
+++ b/cassandra/src/start.sh
@@ -27,7 +27,7 @@ sed -i -e "s/# broadcast_address.*/broadcast_address: $IP/"              $CONFIG
 sed -i -e "s/# broadcast_rpc_address.*/broadcast_rpc_address: $IP/"              $CONFIG/cassandra.yaml
 sed -i -e "s/^commitlog_segment_size_in_mb.*/commitlog_segment_size_in_mb: 64/"              $CONFIG/cassandra.yaml
 sed -i -e "s/- seeds: \"127.0.0.1\"/- seeds: \"$SEEDS\"/"       $CONFIG/cassandra.yaml
-sed -i -e "s/# JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname=<public name>\"/ JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname=$IP\"/" $CONFIG/cassandra-env.sh
+sed -i -e "s/# JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=<public name>\"/JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"/" $CONFIG/cassandra-env.sh
 
 if [[ $SNITCH ]]; then
   sed -i -e "s/endpoint_snitch: SimpleSnitch/endpoint_snitch: $SNITCH/" $CONFIG/cassandra.yaml


### PR DESCRIPTION
I was debugging why i still get a connection refused error when trying this command  in the 3-node cluster section of the README:

docker run -i -t poklet/cassandra nodetool -h $(./scripts/ipof.sh cass1) status

I did not solve it yet, but while digging, I noticed something that may not be what you intended.
I'm pretty much a total noob, so please just disregard if I am wrong here.
