### PR TITLE
Updated start script to enable JMX remote connections for nodetool or opscenter

### DIFF
--- a/cassandra/src/start.sh
+++ b/cassandra/src/start.sh
@@ -28,6 +28,8 @@ sed -i -e "s/# broadcast_rpc_address.*/broadcast_rpc_address: $IP/"             
 sed -i -e "s/^commitlog_segment_size_in_mb.*/commitlog_segment_size_in_mb: 64/"              $CONFIG/cassandra.yaml
 sed -i -e "s/- seeds: \"127.0.0.1\"/- seeds: \"$SEEDS\"/"       $CONFIG/cassandra.yaml
 sed -i -e "s/# JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=<public name>\"/JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"/" $CONFIG/cassandra-env.sh
+sed -i -e "s/LOCAL_JMX=yes/LOCAL_JMX=no/" $CONFIG/cassandra-env.sh
+sed -i -e "s/JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true\"/JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false\"/" $CONFIG/cassandra-env.sh
 
 if [[ $SNITCH ]]; then
   sed -i -e "s/endpoint_snitch: SimpleSnitch/endpoint_snitch: $SNITCH/" $CONFIG/cassandra.yaml


### PR DESCRIPTION

After https://issues.apache.org/jira/browse/CASSANDRA-9085 it appears that 7199 port is closed by default, so to be have ability to use nodetool from docker host or allow opscenter to install agents we need to do more changes to cassandra-env.sh. 
1) Disable only local JMX
2) Disable authentication

(discussion comes from https://github.com/pokle/cassandra/pull/28)